### PR TITLE
Get rid of PROXY_HOST variable which is confusing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,11 +41,11 @@ Quick start
             gateway: 172.18.0.1
 
 3. Run ``./start_ci.sh up -d``
-4. Put WWW content of your ``http://PROXY_HOST`` site to ``/your/volume/path/nginx/html`` (defaults to ``/srv/ci-infra/nginx/html``)
-5. Access ``http://PROXY_HOST`` in your browser:
+4. Put WWW content of your ``http://WEB_SERVER_NAME`` site to ``/your/volume/path/nginx/html`` (defaults to ``/srv/ci-infra/nginx/html``)
+5. Access ``http://WEB_SERVER_NAME`` in your browser:
 
-* Access Gerrit -- ``http://PROXY_HOST/gerrit``
-* Access Jenkins -- ``http://PROXY_HOST/jenkins``
+* Access Gerrit -- ``http://WEB_SERVER_NAME/gerrit``
+* Access Jenkins -- ``http://WEB_SERVER_NAME/jenkins``
 
 6. Stop and remove all containers and networks ``./destroy_ci.sh``
 7. (Optionally) Remove ``VOLUME_PATH`` directory ``./destroy_ci.sh --force`` (defaults to ``/srv/ci-infra``)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ${VOLUME_PATH}/gerrit_volume:/var/gerrit/review_site
     restart: unless-stopped
     environment:
-      WEBURL: http://${PROXY_HOST}/gerrit
+      WEBURL: http://${WEB_SERVER_NAME}/gerrit
       HTTPD_LISTENURL: proxy-http://*:8080/gerrit
       DATABASE_TYPE: mysql
       DB_PORT_3306_TCP_ADDR: db-gerrit
@@ -72,7 +72,7 @@ services:
     volumes:
       - ${VOLUME_PATH}/nginx/html:/usr/share/nginx/html:ro
     environment:
-      SERVER_NAME: ${PROXY_HOST}
+      SERVER_NAME: ${WEB_SERVER_NAME}
       CLIENT_MAX_BODY_SIZE: 200m
     depends_on:
      - gerrit

--- a/env.config
+++ b/env.config
@@ -1,5 +1,5 @@
 # URL to access ci services, e.g. example.domain.com
-export PROXY_HOST=127.0.0.1
+export WEB_SERVER_NAME=ci.infra.local
 
 # Data volume root dir
 export VOLUME_PATH=/srv/ci-infra


### PR DESCRIPTION
We need to define WEB_SERVER_NAME which is one treats as web-root,
then we can address other services, e.g:
  * WEB_SERVER_NAME/gerrit
  * WEB_SERVER_NAME/jenkins

We don't care of technical details (proxy, url_rewrites, etc)